### PR TITLE
[swiftc (118 vs. 5184)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28491-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28491-result-case-not-implemented.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+let a{class d:e
+class B:d class a{}{a
+return $0
+== {


### PR DESCRIPTION
This is a comment.