### PR TITLE
[swiftc (120 vs. 5184)] Add crasher in swift::TypeChecker::resolveIdentifierType

### DIFF
--- a/validation-test/compiler_crashers/28493-resolveidenttypecomponent-swift-typechecker-swift-declcontext-llvm-arrayref-swif.swift
+++ b/validation-test/compiler_crashers/28493-resolveidenttypecomponent-swift-typechecker-swift-declcontext-llvm-arrayref-swif.swift
@@ -1,0 +1,24 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class c:A
+let a
+{
+protocol a{
+func d:A.d:A
+class A:a}} _b(array:b{
+struct g:a{
+let a(){{typealias fb
+protocol a<T>:A{
+let e
+typealias f)typealias etypealias e:d class a:a
+protocol AA.h{protocol {a(){struct g:A{
+typealias fb
+class a)class A:A{func<T where S
+class a:a{class A:f:
+for in.E Int S}typea


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::resolveIdentifierType`.

Current number of unresolved compiler crashers: 120 (5184 resolved)

Stack trace:

```
#0 0x00000000031d10e8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d10e8)
#1 0x00000000031d1936 SignalHandler(int) (/path/to/swift/bin/swift+0x31d1936)
#2 0x00007f152b6e8330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x0000000000df135c swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xdf135c)
#4 0x0000000000df1904 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xdf1904)
#5 0x0000000000df4e2e swift::ConformanceLookupTable::getAllProtocols(swift::NominalTypeDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0xdf4e2e)
#6 0x0000000000dd375f swift::NominalTypeDecl::getAllProtocols() const (/path/to/swift/bin/swift+0xdd375f)
#7 0x0000000000dc800b swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const (/path/to/swift/bin/swift+0xdc800b)
#8 0x0000000000bd0292 swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbd0292)
#9 0x0000000000c08e10 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc08e10)
#10 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#11 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#12 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#13 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#14 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#15 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#16 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#17 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#18 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#19 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#20 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#21 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#22 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#23 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#24 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#25 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#26 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#27 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#28 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#29 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#30 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#31 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#32 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#33 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#34 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#35 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#36 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#37 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#38 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#39 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#40 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#41 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#42 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#43 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#44 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#45 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#46 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#47 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#48 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#49 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#50 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#51 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#52 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#53 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#54 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#55 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#56 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#57 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#58 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#59 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#60 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#61 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#62 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#63 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#64 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#65 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#66 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#67 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#68 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#69 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#70 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#71 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#72 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#73 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#74 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#75 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#76 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#77 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#78 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#79 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#80 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#81 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#82 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#83 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#84 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#85 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#86 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#87 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#88 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#89 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#90 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#91 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#92 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#93 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#94 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#95 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#96 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#97 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#98 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#99 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#100 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#101 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#102 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#103 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#104 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#105 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#106 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#107 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#108 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#109 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#110 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#111 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#112 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#113 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#114 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#115 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#116 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#117 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#118 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#119 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#120 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#121 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#122 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#123 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#124 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#125 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#126 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#127 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#128 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#129 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#130 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#131 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#132 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#133 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#134 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#135 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#136 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#137 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#138 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#139 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#140 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#141 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#142 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#143 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#144 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#145 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#146 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#147 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#148 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#149 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#150 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#151 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#152 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#153 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#154 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#155 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#156 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#157 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#158 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#159 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#160 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#161 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#162 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#163 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#164 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#165 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#166 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#167 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#168 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#169 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#170 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#171 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#172 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#173 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#174 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#175 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#176 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#177 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#178 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#179 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#180 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#181 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#182 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#183 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#184 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#185 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#186 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#187 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#188 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#189 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#190 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#191 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#192 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#193 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#194 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#195 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#196 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#197 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#198 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#199 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#200 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#201 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#202 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#203 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#204 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#205 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#206 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#207 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#208 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#209 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#210 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#211 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#212 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#213 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#214 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#215 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#216 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#217 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#218 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#219 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#220 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#221 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#222 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#223 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#224 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#225 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#226 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#227 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#228 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#229 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#230 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#231 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#232 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#233 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#234 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#235 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#236 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#237 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#238 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#239 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
#240 0x0000000000baea39 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaea39)
#241 0x0000000000ba1f06 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1f06)
#242 0x0000000000b9bebf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9bebf)
#243 0x0000000000bdddbe swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdddbe)
#244 0x0000000000dd249c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd249c)
#245 0x0000000000bcf978 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf978)
#246 0x0000000000bd0109 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbd0109)
#247 0x0000000000bcfef4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfef4)
#248 0x0000000000c11a38 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc11a38)
#249 0x0000000000c0902a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0902a)
#250 0x0000000000c0876d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0876d)
#251 0x0000000000c09888 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc09888)
#252 0x0000000000c0977f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0977f)
#253 0x0000000000c07f19 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07f19)
#254 0x0000000000bcbdb7 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcbdb7)
#255 0x0000000000bcb9e8 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb9e8)
```